### PR TITLE
Improve app with time endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This repository contains a minimal example of a React frontend and FastAPI backe
 The frontend uses Tailwind CSS for styling. The backend exposes a JSON API
 that the frontend consumes.
 
+The API now includes an additional `/api/time` endpoint that returns the
+current server time in ISO format. The frontend displays this value on load.
+
 ## Requirements
 - Node.js and npm (for the frontend)
 - Python 3.11 (for the backend)
@@ -28,6 +31,12 @@ python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 uvicorn main:app --reload
+```
+
+To run the backend tests:
+
+```bash
+python -m unittest
 ```
 
 ### Frontend

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from datetime import datetime
 
 app = FastAPI()
 
@@ -14,3 +15,9 @@ app.add_middleware(
 @app.get("/api/message")
 def read_message():
     return {"message": "Hello from FastAPI"}
+
+
+@app.get("/api/time")
+def get_time():
+    """Return the current server time in ISO format."""
+    return {"time": datetime.utcnow().isoformat() + "Z"}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,18 +2,27 @@ import React, { useEffect, useState } from 'react';
 
 function App() {
   const [message, setMessage] = useState('');
+  const [time, setTime] = useState('');
 
   useEffect(() => {
     fetch('/api/message')
       .then((res) => res.json())
       .then((data) => setMessage(data.message))
       .catch((err) => console.error('Error fetching message', err));
+
+    fetch('/api/time')
+      .then((res) => res.json())
+      .then((data) => setTime(data.time))
+      .catch((err) => console.error('Error fetching time', err));
   }, []);
 
   return (
     <div className="p-4">
       <h1 className="text-2xl font-bold mb-4">School Website</h1>
       <p className="text-blue-600">{message}</p>
+      {time && (
+        <p className="text-gray-700 mt-2" data-testid="server-time">Server time: {time}</p>
+      )}
     </div>
   );
 }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,18 @@
+import unittest
+
+import sys
+sys.path.append('backend')
+from main import app, read_message, get_time
+
+class APITestCase(unittest.TestCase):
+    def test_read_message(self):
+        data = read_message()
+        self.assertIn('message', data)
+
+    def test_get_time(self):
+        data = get_time()
+        self.assertIn('time', data)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- expose `/api/time` on the FastAPI backend
- show server time in the React frontend
- describe the new endpoint and testing in the README
- add lightweight unit tests for the backend

## Testing
- `python3 -m unittest discover -s tests`
